### PR TITLE
Issue: #31 enhance dropdown toggle icon and redirect link onclick

### DIFF
--- a/styles/theme/layout/components/Navbar.tsx
+++ b/styles/theme/layout/components/Navbar.tsx
@@ -7,6 +7,7 @@ import {
     IconButton,
     Button,
     Stack,
+    HStack,
     Collapse,
     Icon,
     Popover,
@@ -194,18 +195,20 @@ const MobileNavItem = ({ label, children, href }: NavItem) => {
                 _hover={{
                     textDecoration: 'none',
                 }}>
-                <Text fontWeight={600} color={useColorModeValue('gray.600', 'gray.200')}>
-                    {label}
-                </Text>
-                {children && (
-                    <Icon
-                        as={ChevronDownIcon}
-                        transition={'all .25s ease-in-out'}
-                        transform={isOpen ? 'rotate(180deg)' : ''}
-                        w={6}
-                        h={6}
-                    />
-                )}
+                <HStack>
+                    <Text fontWeight={600} color={useColorModeValue('gray.600', 'gray.200')}>
+                        {label}
+                    </Text>
+                    {children && (
+                        <Icon
+                            as={ChevronDownIcon}
+                            transition={'all .25s ease-in-out'}
+                            transform={isOpen ? 'rotate(180deg)' : ''}
+                            w={6}
+                            h={6}
+                        />
+                    )}
+                </HStack>
             </Box>
 
             <Collapse in={isOpen} animateOpacity style={{ marginTop: '0!important' }}>

--- a/styles/theme/layout/components/Navbar.tsx
+++ b/styles/theme/layout/components/Navbar.tsx
@@ -58,6 +58,7 @@ export default function WithSubnavigation() {
                             textAlign={useBreakpointValue({ base: 'center', md: 'right' })}
                             color={useColorModeValue('gray.800', 'white')} fontSize={'30px'} cursor={'pointer'}
                             _hover={{ color: 'primary.100' }}
+                            onClick={() => {window.location.href = './'}}
                         >
 
                             Hakto


### PR DESCRIPTION
# Issue #31 style: enhance dropdown toggle icon

I have one addition refractor in this pull-request. Here is what I have done in this pull-request
- enhance drop down toggle icon
- make redirect link on web title Hakto onclick shown in [line 61](https://github.com/husnainakram09/ecommerce/compare/main...Dimas-Saputra-Me:ecommerce:main?expand=1#diff-ac87b1cd84d9b79d3cd324b681d1cb5170e85fe500f77f86d9db40e09fe2e83eR61). So whenever someone click the title, it will redirect it to the base URL

Let me know if there is any feedback or there is something I need to do. Thank you